### PR TITLE
Fix click counter text selection issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ body {
     font-size: 24px;
     color: #333;
     animation: fadeIn 1s ease-in-out;
+    user-select: none;
 }
 
 .click-counter-hidden {


### PR DESCRIPTION
Add CSS property to prevent text selection of click counter text.

* Add `user-select: none;` to the `#click-counter` element in `style.css` to prevent text selection.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/nakazawa.com/pull/4?shareId=aa8dd256-9a16-4d16-8d23-29a05ee0d114).