### PR TITLE
Fix carrot cursor to show on the entire screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@ body {
     background-image: url("bunnies.gif");
     background-repeat: repeat;
     cursor:
-        url("carrot.png") 16 0,
+        url("carrot.png") 16 16,
         auto;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Update the cursor hotspot in `style.css` to ensure the carrot cursor shows up on the entire screen.

* Adjust the cursor hotspot to `16 16` in the `body` selector in `style.css` to center the carrot cursor.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/nakazawa.com/pull/5?shareId=83afca36-bc76-4319-a38c-7d11f917ea1b).