### PR TITLE
Make the language dropdown responsive

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -397,3 +397,16 @@ body {
     z-index: 10;
     display: none;
 }
+
+/* Media query to hide language word in dropdown for screens smaller than 768px */
+@media (max-width: 768px) {
+    #language-select option {
+        display: flex;
+        justify-content: center;
+    }
+
+    #language-select option::after {
+        content: "";
+        display: none;
+    }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -102,20 +102,20 @@
         <div id="flash-message" class="flash-message-hidden"></div>
         <div id="button-container">
             <select id="language-select" class="control-button language-mobile-view">
-                <option value="en">🇺🇸</option>
-                <option value="ja">🇯🇵</option>
-                <option value="es">🇪🇸</option>
-                <option value="zh">🇨🇳</option>
-                <option value="id">🇮🇩</option>
-                <option value="ko">🇰🇷</option>
-                <option value="hi">🇮🇳</option>
-                <option value="pt">🇵🇹</option>
-                <option value="de">🇩🇪</option>
-                <option value="fr">🇫🇷</option>
-                <option value="pl">🇵🇱</option>
-                <option value="zh-TW">🇹🇼</option>
-                <option value="it">🇮🇹</option>
-                <!-- <option value="pirate">🏴‍☠️</option> -->
+                <option value="en" data-emoji="🇺🇸" data-text="English">🇺🇸 English</option>
+                <option value="ja" data-emoji="🇯🇵" data-text="日本語">🇯🇵 日本語</option>
+                <option value="es" data-emoji="🇪🇸" data-text="Español">🇪🇸 Español</option>
+                <option value="zh" data-emoji="🇨🇳" data-text="中文">🇨🇳 中文</option>
+                <option value="id" data-emoji="🇮🇩" data-text="Bahasa Indonesia">🇮🇩 Bahasa Indonesia</option>
+                <option value="ko" data-emoji="🇰🇷" data-text="한국어">🇰🇷 한국어</option>
+                <option value="hi" data-emoji="🇮🇳" data-text="हिन्दी">🇮🇳 हिन्दी</option>
+                <option value="pt" data-emoji="🇵🇹" data-text="Português">🇵🇹 Português</option>
+                <option value="de" data-emoji="🇩🇪" data-text="Deutsch">🇩🇪 Deutsch</option>
+                <option value="fr" data-emoji="🇫🇷" data-text="Français">🇫🇷 Français</option>
+                <option value="pl" data-emoji="🇵🇱" data-text="Polski">🇵🇱 Polski</option>
+                <option value="zh-TW" data-emoji="🇹🇼" data-text="繁體中文">🇹🇼 繁體中文</option>
+                <option value="it" data-emoji="🇮🇹" data-text="Italiano">🇮🇹 Italiano</option>
+                <!-- <option value="pirate" data-emoji="🏴‍☠️" data-text="Pirate">🏴‍☠️ Pirate</option> -->
             </select>
             <button
                 id="fullscreen-button"

--- a/src/index.html
+++ b/src/index.html
@@ -101,7 +101,7 @@
         <div id="timer"></div>
         <div id="flash-message" class="flash-message-hidden"></div>
         <div id="button-container">
-            <select id="language-select" class="control-button">
+            <select id="language-select" class="control-button language-mobile-view">
                 <option value="en">🇺🇸 English</option>
                 <option value="ja">🇯🇵 日本語</option>
                 <option value="es">🇪🇸 Español</option>

--- a/src/index.html
+++ b/src/index.html
@@ -102,20 +102,20 @@
         <div id="flash-message" class="flash-message-hidden"></div>
         <div id="button-container">
             <select id="language-select" class="control-button language-mobile-view">
-                <option value="en">🇺🇸 English</option>
-                <option value="ja">🇯🇵 日本語</option>
-                <option value="es">🇪🇸 Español</option>
-                <option value="zh">🇨🇳 中文</option>
-                <option value="id">🇮🇩 Bahasa Indonesia</option>
-                <option value="ko">🇰🇷 한국어</option>
-                <option value="hi">🇮🇳 हिन्दी</option>
-                <option value="pt">🇵🇹 Português</option>
-                <option value="de">🇩🇪 Deutsch</option>
-                <option value="fr">🇫🇷 Français</option>
-                <option value="pl">🇵🇱 Polski</option>
-                <option value="zh-TW">🇹🇼 繁體中文</option>
-                <option value="it">🇮🇹 Italiano</option>
-                <!-- <option value="pirate">🏴‍☠️ Pirate</option> -->
+                <option value="en">🇺🇸</option>
+                <option value="ja">🇯🇵</option>
+                <option value="es">🇪🇸</option>
+                <option value="zh">🇨🇳</option>
+                <option value="id">🇮🇩</option>
+                <option value="ko">🇰🇷</option>
+                <option value="hi">🇮🇳</option>
+                <option value="pt">🇵🇹</option>
+                <option value="de">🇩🇪</option>
+                <option value="fr">🇫🇷</option>
+                <option value="pl">🇵🇱</option>
+                <option value="zh-TW">🇹🇼</option>
+                <option value="it">🇮🇹</option>
+                <!-- <option value="pirate">🏴‍☠️</option> -->
             </select>
             <button
                 id="fullscreen-button"


### PR DESCRIPTION
Make the language dropdown responsive for mobile view by displaying only the emoji.

* Add a media query in `src/css/style.css` to hide the language word in the dropdown for screens smaller than 768px.
* Modify the `#language-select` styles in `src/css/style.css` to display only the emoji in mobile view.
* Update the `#language-select` element in `src/index.html` to include a class for mobile view.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/nakazawa.com/pull/20?shareId=4a6d258b-3ef0-4367-9d11-1a790920f773).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced language selection dropdown styling for mobile screens.
	- Added responsive design improvements to center language options on smaller devices.
	- Simplified language options display by showing only flag emojis in the dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->